### PR TITLE
Add CSV bulk conversion endpoint and test file convert-csv.http

### DIFF
--- a/api-requests/fx-api/convert-csv.http
+++ b/api-requests/fx-api/convert-csv.http
@@ -1,0 +1,16 @@
+### Test: Bulk currency conversion with CSV file upload
+# This request sends a CSV file to /api/v1/convert/csv endpoint
+# and expects a list of conversion results in response.
+
+POST http://localhost:8080/api/v1/convert/csv
+Content-Type: multipart/form-data; boundary=boundary
+
+--boundary
+Content-Disposition: form-data; name="file"; filename="test.csv"
+Content-Type: text/csv
+
+amount,from,to
+100,USD,TRY
+250,EUR,USD
+75,GBP,JPY
+--boundary--

--- a/fx-api/pom.xml
+++ b/fx-api/pom.xml
@@ -70,6 +70,11 @@
             <version>2.2.0</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>1.10.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/fx-api/src/main/java/com/borayuret/fxapi/controller/CurrencyConversionController.java
+++ b/fx-api/src/main/java/com/borayuret/fxapi/controller/CurrencyConversionController.java
@@ -1,5 +1,6 @@
 package com.borayuret.fxapi.controller;
 
+import com.borayuret.fxapi.dto.BulkCurrencyConversionResponseDTO;
 import com.borayuret.fxapi.dto.CurrencyConversionRequestDTO;
 import com.borayuret.fxapi.dto.CurrencyConversionResponseDTO;
 import com.borayuret.fxapi.model.CurrencyConversion;
@@ -13,6 +14,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.util.UUID;
@@ -86,6 +88,27 @@ public class CurrencyConversionController {
             Pageable pageable) {
 
         return conversionService.getConversionHistory(transactionId, date, pageable);
+    }
+
+
+    /**
+     * Accepts a CSV file upload and performs bulk currency conversion.
+     *
+     * @param file CSV file with rows like: amount,from,to
+     * @return list of conversion results for each row
+     */
+    @Operation(
+            summary = "Bulk currency conversion via CSV upload",
+            description = "Processes a CSV file containing multiple currency conversion requests."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "All conversions processed successfully"),
+            @ApiResponse(responseCode = "400", description = "Invalid CSV format or file upload error"),
+            @ApiResponse(responseCode = "500", description = "Unexpected server error")
+    })
+    @PostMapping(value = "/convert/csv", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public BulkCurrencyConversionResponseDTO convertCsv(@RequestPart("file") MultipartFile file) {
+        return conversionService.convertFromCsv(file);
     }
 
 }

--- a/fx-api/src/main/java/com/borayuret/fxapi/dto/BulkCurrencyConversionResponseDTO.java
+++ b/fx-api/src/main/java/com/borayuret/fxapi/dto/BulkCurrencyConversionResponseDTO.java
@@ -1,0 +1,30 @@
+package com.borayuret.fxapi.dto;
+
+import java.util.List;
+
+/**
+ * DTO representing the response to a bulk currency conversion.
+ * Contains a list of results for each row in the CSV file.
+ */
+public class BulkCurrencyConversionResponseDTO {
+
+    /**
+     * List of successful currency conversion results,
+     * each including converted amount and transaction ID.
+     */
+    private List<CurrencyConversionResponseDTO> results;
+
+    public BulkCurrencyConversionResponseDTO() {}
+
+    public BulkCurrencyConversionResponseDTO(List<CurrencyConversionResponseDTO> results) {
+        this.results = results;
+    }
+
+    public List<CurrencyConversionResponseDTO> getResults() {
+        return results;
+    }
+
+    public void setResults(List<CurrencyConversionResponseDTO> results) {
+        this.results = results;
+    }
+}

--- a/fx-api/src/main/java/com/borayuret/fxapi/dto/CsvCurrencyConversionRequestDTO.java
+++ b/fx-api/src/main/java/com/borayuret/fxapi/dto/CsvCurrencyConversionRequestDTO.java
@@ -1,0 +1,55 @@
+package com.borayuret.fxapi.dto;
+
+/**
+ * DTO representing a single row in the uploaded CSV file.
+ * Each row defines one currency conversion request with amount, source, and target currencies.
+ */
+public class CsvCurrencyConversionRequestDTO {
+
+    /**
+     * The amount to be converted.
+     */
+    private double amount;
+
+    /**
+     * The currency code to convert from (e.g. "USD").
+     */
+    private String from;
+
+    /**
+     * The currency code to convert to (e.g. "EUR").
+     */
+    private String to;
+
+    public CsvCurrencyConversionRequestDTO() {}
+
+    public CsvCurrencyConversionRequestDTO(double amount, String from, String to) {
+        this.amount = amount;
+        this.from = from;
+        this.to = to;
+    }
+
+    public double getAmount() {
+        return amount;
+    }
+
+    public void setAmount(double amount) {
+        this.amount = amount;
+    }
+
+    public String getFrom() {
+        return from;
+    }
+
+    public void setFrom(String from) {
+        this.from = from;
+    }
+
+    public String getTo() {
+        return to;
+    }
+
+    public void setTo(String to) {
+        this.to = to;
+    }
+}

--- a/fx-api/src/main/java/com/borayuret/fxapi/dto/CsvCurrencyConversionRequestDTO.java~
+++ b/fx-api/src/main/java/com/borayuret/fxapi/dto/CsvCurrencyConversionRequestDTO.java~
@@ -1,0 +1,39 @@
+package com.borayuret.fxapi.dto;
+
+public class CsvCurrencyConversionRequestDTO {
+    private double amount;
+    private String from;
+    private String to;
+
+    public CsvCurrencyConversionRequestDTO() {}
+
+    public CsvCurrencyConversionRequestDTO(double amount, String from, String to) {
+        this.amount = amount;
+        this.from = from;
+        this.to = to;
+    }
+
+    public double getAmount() {
+        return amount;
+    }
+
+    public void setAmount(double amount) {
+        this.amount = amount;
+    }
+
+    public String getFrom() {
+        return from;
+    }
+
+    public void setFrom(String from) {
+        this.from = from;
+    }
+
+    public String getTo() {
+        return to;
+    }
+
+    public void setTo(String to) {
+        this.to = to;
+    }
+}


### PR DESCRIPTION
Implements bulk currency conversion using CSV file upload.

- Adds POST /api/v1/convert/csv endpoint
- Parses uploaded CSV using Apache Commons CSV
- Performs conversion per row and returns list of responses
- Adds convert-csv.http for testing the endpoint
