### PR TITLE
Add JaCoCo plugin for code coverage reporting

### DIFF
--- a/fx-api/pom.xml
+++ b/fx-api/pom.xml
@@ -108,6 +108,27 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <!-- JaCoCo Plugin -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.11</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/fx-api/pom.xml~
+++ b/fx-api/pom.xml~
@@ -69,6 +69,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
### Summary

This pull request integrates **JaCoCo** into the project to enable test coverage reporting for unit and service layer tests.

---

### Key Changes

- Added `jacoco-maven-plugin` to `pom.xml`
- Configured report generation during `verify` phase
- Coverage report is generated under:
  `target/site/jacoco/index.html`

---

### How to Use

Run the following command to generate the report:
```bash
./mvnw clean verify
